### PR TITLE
fix version of images in docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ version: '3.5'
 
 services:
   storage:
-    image: openzipkin/zipkin-mysql
+    image: openzipkin/zipkin-mysql:1
     container_name: mysql
     networks:
       - zipkin
@@ -191,7 +191,7 @@ services:
   # The zipkin process services the UI, and also exposes a POST endpoint that
   # instrumentation can send trace data to. Scribe is disabled by default.
   zipkin:
-    image: openzipkin/zipkin
+    image: openzipkin/zipkin:1
     container_name: zipkin
     networks:
       - zipkin
@@ -213,7 +213,7 @@ services:
   #
   # For more details, see https://github.com/openzipkin/docker-zipkin-dependencies
   dependencies:
-    image: openzipkin/zipkin-dependencies
+    image: openzipkin/zipkin-dependencies:1
     container_name: dependencies
     entrypoint: crond -f
     networks:

--- a/docker-compose.zipkin.yml
+++ b/docker-compose.zipkin.yml
@@ -5,7 +5,7 @@ version: '3.5'
 
 services:
   storage:
-    image: openzipkin/zipkin-mysql
+    image: openzipkin/zipkin-mysql:1
     container_name: mysql
     networks:
       - zipkin
@@ -15,7 +15,7 @@ services:
   # The zipkin process services the UI, and also exposes a POST endpoint that
   # instrumentation can send trace data to. Scribe is disabled by default.
   zipkin:
-    image: openzipkin/zipkin
+    image: openzipkin/zipkin:1
     container_name: zipkin
     networks:
       - zipkin
@@ -37,7 +37,7 @@ services:
   #
   # For more details, see https://github.com/openzipkin/docker-zipkin-dependencies
   dependencies:
-    image: openzipkin/zipkin-dependencies
+    image: openzipkin/zipkin-dependencies:1
     container_name: dependencies
     entrypoint: crond -f
     networks:


### PR DESCRIPTION
New major version of Zipkin were released [1].
But our version of tracing module was tested only with v1. Also
seems some docker containers were changed as well. MySQL
containser seems to support only v1 [2]. Seems eventually we
should replace it with Cassandra that supports v2 [3] (maybe).
But this patch just downgrade zipkin version in
docker-compose.zipkin.yml file because anyway even we could run
zipkin v2 + cassandra storage we can't give any guarantee that it
will work until [4].

  [1] https://github.com/openzipkin/zipkin/releases/tag/2.0.0
  [2] https://github.com/openzipkin/zipkin/tree/master/zipkin-storage/mysql-v1
  [3] https://github.com/openzipkin/zipkin-dependencies#cassandra
  [4] https://github.com/tarantool/tracing/issues/13

Closes #10