### PR TITLE
Remove http v2 from readme

### DIFF
--- a/.github/workflows/test_on_push.yaml
+++ b/.github/workflows/test_on_push.yaml
@@ -11,7 +11,7 @@ jobs:
   run-tests-ce:
     strategy:
       matrix:
-        tarantool-version: ["1.10", "2.3", "2.4", "2.5"]
+        tarantool-version: ["1.10", "2.8"]
       fail-fast: false
     runs-on: [ubuntu-latest]
     steps:

--- a/README.md
+++ b/README.md
@@ -165,15 +165,14 @@ and `publisher` that prints it in the console.
 
 Add data to these services via HTTP; initially it sends `client`.
 
-*Note: example requires http rock (version >= 2.0.1)*
-*Install it using `tarantoolctl rocks install http 2.0.1`*
+*Note: example requires http rock (version >= 1.2.0)*
+*Install it using `tarantoolctl rocks install http 1.2.0`*
 
 #### How to run
 
 * Create `docker-compose.zipkin.yml`
 
 ```yaml
-
 ---
 version: '3.5'
 
@@ -242,7 +241,6 @@ Formatter HTTP server
 #!/usr/bin/env tarantool
 
 local http_server = require('http.server')
-local http_router = require('http.router')
 local fiber = require('fiber')
 local log = require('log')
 local zipkin = require('zipkin.tracer')
@@ -259,7 +257,7 @@ local PORT = '33302'
 
 local function handler(req)
     -- Extract content from request's http headers
-    local ctx, err = opentracing.http_extract(req:headers())
+    local ctx, err = opentracing.http_extract(req.headers)
     if ctx == nil then
         local resp = req:render({ text = err })
         resp.status = 400
@@ -301,9 +299,7 @@ function app.init()
     opentracing.set_global_tracer(tracer)
 
     local httpd = http_server.new(HOST, PORT)
-    local router = http_router.new()
-        :route({ path = '/format', method = 'GET' }, handler)
-    httpd:set_router(router)
+    httpd:route({ path = '/format', method = 'GET' }, handler)
     httpd:start()
 end
 
@@ -317,7 +313,6 @@ Publisher HTTP server
 #!/usr/bin/env tarantool
 
 local http_server = require('http.server')
-local http_router = require('http.router')
 local fiber = require('fiber')
 local log = require('log')
 local zipkin = require('zipkin.tracer')
@@ -333,7 +328,7 @@ local HOST = '0.0.0.0'
 local PORT = '33303'
 
 local function handler(req)
-    local ctx, err = opentracing.http_extract(req:headers())
+    local ctx, err = opentracing.http_extract(req.headers)
 
     if ctx == nil then
         local resp = req:render({ text = err })
@@ -369,9 +364,7 @@ function app.init()
     opentracing.set_global_tracer(tracer)
 
     local httpd = http_server.new(HOST, PORT)
-    local router = http_router.new()
-        :route({ path = '/print', method = 'GET' }, handler)
-    httpd:set_router(router)
+    httpd:route({ path = '/print', method = 'GET' }, handler)
     httpd:start()
 end
 

--- a/examples/http/formatter/init.lua
+++ b/examples/http/formatter/init.lua
@@ -1,14 +1,12 @@
 #!/usr/bin/env tarantool
 
-local ok, http_server = pcall(require,'http.server')
-
+local ok, http_server = pcall(require, 'http.server')
 if not ok then
-    print('Example requires http module (version >= 2.0.1)')
-    print('Install using "tarantoolctl rocks install http 2.0.1"')
+    print('Example requires http module (version >= 1.2.0)')
+    print('Install using "tarantoolctl rocks install http 1.2.0"')
     os.exit(1)
 end
 
-local http_router = require('http.router')
 local fiber = require('fiber')
 local log = require('log')
 local zipkin = require('zipkin.tracer')
@@ -25,7 +23,7 @@ local PORT = '33302'
 
 local function handler(req)
     -- Extract content from request's http headers
-    local ctx, err = opentracing.http_extract(req:headers())
+    local ctx, err = opentracing.http_extract(req.headers)
     if ctx == nil then
         local resp = req:render({ text = err })
         resp.status = 400
@@ -67,8 +65,7 @@ function app.init()
     opentracing.set_global_tracer(tracer)
 
     local httpd = http_server.new(HOST, PORT)
-    local router = http_router.new():route({ path = '/format', method = 'GET' }, handler)
-    httpd:set_router(router)
+    httpd:route({ path = '/format', method = 'GET' }, handler)
     httpd:start()
 end
 

--- a/examples/http/publisher/init.lua
+++ b/examples/http/publisher/init.lua
@@ -1,15 +1,12 @@
 #!/usr/bin/env tarantool
 
-
-local ok, http_server = pcall(require,'http.server')
-
+local ok, http_server = pcall(require, 'http.server')
 if not ok then
-    print('Example requires http module (version >= 2.0.1)')
-    print('Install using "tarantoolctl rocks install http 2.0.1"')
+    print('Example requires http module (version >= 1.2.0)')
+    print('Install using "tarantoolctl rocks install http 1.2.0"')
     os.exit(1)
 end
 
-local http_router = require('http.router')
 local fiber = require('fiber')
 local log = require('log')
 local zipkin = require('zipkin.tracer')
@@ -25,7 +22,7 @@ local HOST = '0.0.0.0'
 local PORT = '33303'
 
 local function handler(req)
-    local ctx, err = opentracing.http_extract(req:headers())
+    local ctx, err = opentracing.http_extract(req.headers)
 
     if ctx == nil then
         local resp = req:render({ text = err })
@@ -61,8 +58,7 @@ function app.init()
     opentracing.set_global_tracer(tracer)
 
     local httpd = http_server.new(HOST, PORT)
-    local router = http_router.new():route({ path = '/print', method = 'GET' }, handler)
-    httpd:set_router(router)
+    httpd:route({ path = '/print', method = 'GET' }, handler)
     httpd:start()
 end
 

--- a/tracing-scm-1.rockspec
+++ b/tracing-scm-1.rockspec
@@ -14,7 +14,7 @@ description = {
 
 dependencies = {
 	'lua >= 5.1',
-	'checks >= 3.0.1',
+	'checks >= 3.1.0',
 }
 
 build = {


### PR DESCRIPTION
This patch partially reverts commit 1d31569a3a928b20f8eab9d960bdb5decc32b712.
Since http v2 was discarded we should use HTTP v1 again. Also some
dependencies were updated.

Closes #15