### PR TITLE
api: add hardcoded versioning support

### DIFF
--- a/.github/workflows/test_on_push.yaml
+++ b/.github/workflows/test_on_push.yaml
@@ -8,6 +8,26 @@ env:
   ROCK_NAME: "tracing"
 
 jobs:
+  version-check-opentracing:
+    # We need this job to run only on push with tag.
+    if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check module version
+        uses: tarantool/actions/check-module-version@master
+        with:
+          module-name: 'opentracing'
+
+  version-check-zipkin:
+    # We need this job to run only on push with tag.
+    if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check module version
+        uses: tarantool/actions/check-module-version@master
+        with:
+          module-name: 'zipkin.tracer'
+
   run-tests-ce:
     strategy:
       matrix:
@@ -37,20 +57,24 @@ jobs:
       - name: Build doc
         run: .rocks/bin/ldoc -t "$ROCK_NAME-${version}" -p "$ROCK_NAME (${version})" --all .
 
-  push-rockspec:
+  push-rockspec-scm-1:
     runs-on: [ ubuntu-latest ]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     steps:
       - uses: actions/checkout@master
       - name: Push scm rockspec
-        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         run: |
           curl --fail -X PUT -F rockspec=@$ROCK_NAME-scm-1.rockspec \
             https://${{ secrets.ROCKS_USERNAME }}:${{ secrets.ROCKS_PASSWORD }}@${{ secrets.ROCKS_SERVER }}
+
+  push-rockspec-tag:
+    runs-on: [ ubuntu-latest ]
+    if: github.event_name == 'push' && github.ref == 'refs/tags/'
+    needs: [version-check-opentracing, version-check-zipkin]
+    steps:
+      - uses: actions/checkout@master
       - name: Push release rockspec
-        if: github.event_name == 'push' && github.ref == 'refs/tags/'
         run: |
-          curl --fail -X PUT -F rockspec=@$ROCK_NAME-scm-1.rockspec \
-            https://${{ secrets.ROCKS_USERNAME }}:${{ secrets.ROCKS_PASSWORD }}@${{ secrets.ROCKS_SERVER }} \
           cat $ROCK_NAME-scm-1.rockspec |
               sed -E \
                 -e "s/branch = '.+'/tag = '$GITHUB_REF'/g" \

--- a/.github/workflows/test_on_push.yaml
+++ b/.github/workflows/test_on_push.yaml
@@ -31,15 +31,19 @@ jobs:
   run-tests-ce:
     strategy:
       matrix:
-        tarantool-version: ["1.10", "2.8"]
+        tarantool-version: ["1.10", "2.10"]
       fail-fast: false
-    runs-on: [ubuntu-latest]
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@master
+
+      - name: Setup Tarantool CE
+        uses: tarantool/setup-tarantool@v2
+        with:
+          tarantool-version: ${{ matrix.tarantool-version }}
+
       - name: Install requirements for community
         run: |
-          curl -L https://tarantool.io/installer.sh | sudo VER=${{ matrix.tarantool-version }} bash
-          sudo apt install -y tarantool-dev
           curl -sSL https://zipkin.io/quickstart.sh | bash -s
           tarantoolctl rocks install ldoc --server=http://rocks.moonscript.org
           tarantoolctl rocks install luacheck 0.25.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Versioning support
+
 ## [0.1.1] - 2019-11-06
 
 - Improve performance

--- a/tracing-scm-1.rockspec
+++ b/tracing-scm-1.rockspec
@@ -23,6 +23,7 @@ build = {
 	install = {
 		lua = {
 			['opentracing'] = 'tracing/opentracing/init.lua',
+			['opentracing.version'] = 'tracing/version.lua',
 			['opentracing.span'] = 'tracing/opentracing/span.lua',
 			['opentracing.span_context'] = 'tracing/opentracing/span_context.lua',
 			['opentracing.tracer'] = 'tracing/opentracing/tracer.lua',
@@ -37,6 +38,7 @@ build = {
 			['zipkin.reporter'] = 'tracing/zipkin/reporter.lua',
 			['zipkin.tracer'] = 'tracing/zipkin/tracer.lua',
 			['zipkin.bounded_queue'] = 'tracing/zipkin/bounded_queue.lua',
+			['zipkin.version'] = 'tracing/version.lua',
 		},
 	},
 	build_variables = {

--- a/tracing/opentracing/init.lua
+++ b/tracing/opentracing/init.lua
@@ -114,4 +114,8 @@ opentracing.map_extract = extractors.map
 opentracing.http_inject = injectors.http
 opentracing.map_inject = injectors.map
 
+-- @tfield string _VERSION
+--  Module version.
+opentracing._VERSION = require('opentracing.version')
+
 return opentracing

--- a/tracing/version.lua
+++ b/tracing/version.lua
@@ -1,0 +1,4 @@
+-- Сontains the module version.
+-- Requires manual update in case of release commit.
+
+return '0.1.1'

--- a/tracing/zipkin/tracer.lua
+++ b/tracing/zipkin/tracer.lua
@@ -43,4 +43,8 @@ function Tracer.new(config, sampler)
     return self
 end
 
+-- @tfield string _VERSION
+--  Module version.
+Tracer._VERSION = require('zipkin.version')
+
 return Tracer


### PR DESCRIPTION
Add versioning support, now the module api has `_VERSION` hardcoded variable. Is part of the task [1].

1. https://github.com/tarantool/roadmap-internal/issues/204